### PR TITLE
fix(how-to-start-jitting): typo

### DIFF
--- a/posts/4.how-to-start-jitting.md
+++ b/posts/4.how-to-start-jitting.md
@@ -183,7 +183,7 @@ var ast = esprima.parse(process.argv[2]);
 // Compile
 var fn = jit.compile(function() {
   // This will generate default entry boilerplate
-  this.Proc(functon() {
+  this.Proc(function() {
     visit.call(this, ast);
 
     // The result should be in 'rax' at this point


### PR DESCRIPTION
It's minor fix, just because the program(code example) failing now.
Besides, great work. thanks
